### PR TITLE
.github,Makefile: add kustomize testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - "*"
+  pull_request:
+    branches: [ main ]
+  schedule:
+  - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Kubernetes tests
+        uses: stefanprodan/kube-tools@v1
+        with:
+          kustomize: 4.2.0
+          command: |
+            CONTAINERIZE_TEST=false make test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,23 @@
-.PHONY: all secrets
+.PHONY: all secrets test
 
 CLUSTER ?= k
-SECRETS := $(shell grep -r -l "^kind: Secret$$" ./apps/$(CLUSTER)/{adjacency,binomial,dashboard,external-dns,fluxcdbot,flux-system,kilo-ui,matchbox,monitoring})
+SECRETS := $(shell grep -r -l "^kind: Secret$$" $(addprefix apps/$(CLUSTER)/,adjacency binomial dashboard external-dns fluxcdbot flux-system kilo-ui matchbox monitoring))
 SEALED_SECRETS := $(addsuffix -sealed.yaml,$(basename $(SECRETS)))
 MONITORING_MANIFESTS = $(shell find apps/base/monitoring/setup apps/base/monitoring -maxdepth 1 -type f -name '*.yaml' | sed 's|^apps/base/monitoring/||g' | grep -v 'kustomization\.yaml$$' | grep -v '-secret.yaml$$' | grep -v '^patch-.*.yaml$$')
+
+TEST_IMAGE := stefanprodan/kube-tools
+KUSTOMIZE_VER ?= 4.2.0
+CONTAINERIZE_TEST ?= true
+TEST_PREFIX :=
+TEST_SUFIX :=
+ifeq ($(CONTAINERIZE_TEST), true)
+	TEST_PREFIX := docker run --rm \
+		-it \
+		-v $(shell pwd):/infrastructure \
+		-w /infrastructure \
+		$(TEST_IMAGE) '
+	TEST_SUFIX := ' '' $(KUSTOMIZE_VER)
+endif
 
 all: $(SEALED_SECRETS) clusters/$(CLUSTER)/sealed-secrets-controller-certificate.pem
 
@@ -22,3 +36,12 @@ apps/base/monitoring:
 
 apps/base/monitoring/kustomization.yaml: apps/base/monitoring apps/base/monitoring/kustomization.yaml.tmpl $(addprefix apps/base/monitoring/,$(MONITORING_MANIFESTS))
 	cat apps/base/monitoring/kustomization.yaml.tmpl | sed "s|\$$RESOURCES|$$(echo -n $(foreach manifest,$(MONITORING_MANIFESTS),\"$(manifest)\",) | sed 's/,$$//')|g" > $@
+
+test:
+	@$(TEST_PREFIX) \
+		for k in $$(grep -r -l "^kind: Kustomization$$" $(addsuffix /$(CLUSTER), apps clusters) | grep "kustomization\.yaml$$"); do \
+			echo "testing $$k"; \
+			kustomize build $$(dirname $$k) > /dev/null && \
+			kustomize build $$(dirname $$k) | kubeval --ignore-missing-schemas --strict; \
+		done \
+	$(TEST_SUFIX)


### PR DESCRIPTION
This commit introduces tests for all of the Kustomize code that build
every kustomization.yaml file in the repository and then pass the result
to kubeval. These commit also adds a GitHub actions workflow to runs the
tests in CI.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>